### PR TITLE
Updated typings/index.d.ts

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,4 +1,4 @@
-declare var Prism;
+declare var Prism: any;
 declare module 'prismjs' {
   export default Prism;
 }


### PR DESCRIPTION
We are having a "ERROR in node_modules/@ngx-prism/core/typings/index.d.ts(1,13): error TS7005: Variable 'Prism' implicitly has an 'any' type. [exit: 1]" error if we set strict mode to true in our Angular project.